### PR TITLE
Only selects files of appropriate extension, ".bst"

### DIFF
--- a/src/components/Brainstormer/Sidebar/Sidebar.tsx
+++ b/src/components/Brainstormer/Sidebar/Sidebar.tsx
@@ -17,7 +17,7 @@ export default function Sidebar(props: SidebarProps) {
                         <Label for="exampleFile" alignment="center">
                             Upload Project File
                         </Label>
-                        <Input type="file" name="file" id="exampleFile" />
+                        <Input type="file" name="file" id="exampleFile" accept=".bst"/>
                         <FormText color="muted">
                             Already got a brainstorm going? Upload it here to continue working!
                         </FormText>


### PR DESCRIPTION
Just made an arbitrary decision that any of our types of files would be ".bst" because why not.